### PR TITLE
Remove safe_where_queries rule as a pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -13,12 +13,6 @@
   entry: ruby.py
   language: script
   files: \.(rb|rake)$
-- id: safe_where_queries_in_parsing
-  name: Only allowed model method is mass_insert in parsing
-  entry: Reservation\s*\.(?!(mass|calendar|hotel_pms_res|set_canceled|update_from)).*
-  language: pcre
-  files: \.rb$
-  args: [-bzo]
 - id: no_commas_in_string_arrays
   name: Do not forget a comma in a %w() string array
   entry: \%w\([^)]*,[^)]*\)


### PR DESCRIPTION
This check is no longer needed in the underlying code after (https://github.com/pricematch/admin/pull/1426).