### PR TITLE
update to use pygrep lang

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,12 +1,12 @@
 - id: do_not_commit
   name: Block if "DO NOT COMMIT" is found
   entry: DO NOT COMMIT
-  language: pcre
+  language: pygrep
   files: ''
 - id: ruby_timezones
   name: Force explicit usage of timezones
   entry: "(Date.today|Time.now|DateTime.now)([ ,)]|$)"
-  language: pcre
+  language: pygrep
   files: \.(rb|rake)$
 - id: ruby
   name: ruby_syntax
@@ -16,40 +16,40 @@
 - id: restrict_methods_on_reservation_table
   name: Only allow limited methods on the Reservation model in parsing
   entry: \bReservation\s*\.(?!(mass|calendar|hotel_pms_res|set_canceled|update_from)).*
-  language: pcre
+  language: pygrep
   files: \.rb$
   args: [-bzo]
 - id: no_commas_in_string_arrays
   name: Do not forget a comma in a %w() string array
   entry: \%w\([^)]*,[^)]*\)
-  language: pcre
+  language: pygrep
   files: \.(rb|rake)$
   args: [-bzo]
 - id: check_rails_env_with_methods
   name: Do not write "Rails.env =" to avoid assignment
   entry: Rails\.env\s*=
-  language: pcre
+  language: pygrep
   files: \.(rb|rake)$
 - id: remove_encoding_comment
   name: Remove the encoding comment at beginning of file
   entry: coding\s*\:\s*utf\-8
-  language: pcre
+  language: pygrep
   files: \.(rb|rake)$
 - id: forbid_describe_only
   name: Do not forget describe.only in test files
   entry: describe.only
-  language: pcre
+  language: pygrep
   files: \.js$
 - id: include_rails_helper_in_tests
   name: Start your spec files with the line `include 'rails_helper'`
   entry: \A(?!(require\s\'rails_helper\')).*
-  language: pcre
+  language: pygrep
   files: spec\.rb$
   args: [-bzo]
 - id: no_puts_statements
   name: Do not leave puts statements in production code
   entry: "[.\\s]?puts[(\\s]?.*"
-  language: pcre
+  language: pygrep
   files: \.rb$
   args: [-bzo]
 - id: remove_ipython_notebook_outputs
@@ -60,5 +60,5 @@
 - id: no_httparty
   name: Use HypertextTransfer wrapper instead of HTTParty directly
   entry: HTTParty
-  language: pcre
+  language: pygrep
   files: \.(rb|rake)$


### PR DESCRIPTION
The PCRE language is going to be removed in pre-commit v.2 - see https://github.com/pre-commit/pre-commit/issues/634 - and the use of pygrep is recommended in its place. Currently, using these hooks results in deprecation warnings being shown to the user.

This pull request updates all hooks to use pygrep where appropriate.